### PR TITLE
[TravisCI] Remove go master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: go
 go:
   - 1.9.x
   - 1.10.x
-  - master
 go_import_path: github.com/wgplaner/wg_planer_server/
 
 addons:


### PR DESCRIPTION
Go master currently fails on downloading dependencies that aren't ours. Will have to check this in a few weeks again.